### PR TITLE
fix: add `platform: 'Web'` to `ReqRequestConnection`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -173,6 +173,10 @@ async function requestText(url, options = {}) {
 }
 
 function loadProtoTypes(liqiJson) {
+  liqiJson.nested.lq.nested.ReqRequestConnection.fields.platform ??= {
+    type: 'string',
+    id: 6
+  };
   const root = protobuf.Root.fromJSON(liqiJson);
   return Object.fromEntries(
     Object.entries(PROTO_TYPES).map(([key, typeName]) => [key, root.lookupType(typeName)])
@@ -390,7 +394,8 @@ async function createSessionForRoute(context, route, credentials) {
     {
       type: 1,
       route_id: route.id,
-      timestamp: Date.now()
+      timestamp: Date.now(),
+      platform: 'Web'
     },
     proto.ResRequestConnection
   );


### PR DESCRIPTION
ko: `lq.Route.requestConnection` call의 `ReqRequestConnection`에 `platform: 'Web'`이 없어 151 에러가 나오는 버그를 해결하였습니다.

en: Fixed a bug where the `lq.Route.requestConnection` call returned error 151 because `platform: 'Web'` was missing from its `ReqRequestConnection`.

Fixes #6
Fixes #7
